### PR TITLE
add version constraint for transitive log4j dependency

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -49,6 +49,10 @@ repositories {
 
 dependencies {
     api("com.github.jengelman.gradle.plugins:shadow:${property("shadow.version")}")
+    constraints {
+        //not used for logging, only PluginCache is used
+        implementation("org.apache.logging.log4j:log4j-core:2.16.0")
+    }
 }
 
 gradlePlugin {

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-version=2.1.1
+version=2.1.2
 #
 # main dependencies
 #


### PR DESCRIPTION
**Changes**
Add version constraint for transitive log4j dependency, that is not used for logging.