### PR TITLE
Disable setup-gradle Enhanced Caching and delegate to setup-java

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -13,12 +13,15 @@ jobs:
       - name: Setup Java
         uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5
         with:
+          cache: gradle
           distribution: temurin
           java-version: |
             11
             21
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@50e97c2cd7a37755bbfafc9c5b7cafaece252f6e # v6
+        with:
+          cache-disabled: true
       - name: Check
         env:
           ORG_GRADLE_PROJECT_signingKey: ${{ secrets.SIGNING_KEY }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -13,12 +13,15 @@ jobs:
       - name: Setup Java
         uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5
         with:
+          cache: gradle
           distribution: temurin
           java-version: |
             11
             21
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@50e97c2cd7a37755bbfafc9c5b7cafaece252f6e # v6
+        with:
+          cache-disabled: true
       - name: Check
         env:
           ORG_GRADLE_PROJECT_signingKey: ${{ secrets.SIGNING_KEY }}


### PR DESCRIPTION
## Summary

- Disable `setup-gradle` proprietary Enhanced Caching (`cache-disabled: true`) across all workflows
- Delegate caching to `setup-java` with `cache: gradle` (MIT-licensed, writes on all branches)
- Remove `gradle-home-cache-includes` blocks where present (Enhanced-only, no longer needed)

Tracked by [INT-247](https://linear.app/hivemq/issue/INT-247)