### PR TITLE
Annotate HivemqExtensionZip as cacheable and stabilise archive output

### DIFF
--- a/src/main/kotlin/com/hivemq/extension/gradle/HivemqExtensionZip.kt
+++ b/src/main/kotlin/com/hivemq/extension/gradle/HivemqExtensionZip.kt
@@ -17,6 +17,7 @@ package com.hivemq.extension.gradle
 
 import org.gradle.api.file.DuplicatesStrategy
 import org.gradle.api.provider.Property
+import org.gradle.api.tasks.CacheableTask
 import org.gradle.api.tasks.Internal
 import org.gradle.api.tasks.bundling.Zip
 import org.gradle.kotlin.dsl.property
@@ -26,6 +27,7 @@ import org.gradle.kotlin.dsl.property
  *
  * @author Silvio Giebl
  */
+@CacheableTask
 abstract class HivemqExtensionZip : Zip() {
 
     /**
@@ -56,5 +58,7 @@ abstract class HivemqExtensionZip : Zip() {
         mainSpec.from(jar) { rename { "${id.get()}-${version.get()}.jar" } }
         rootSpec.into(id)
         duplicatesStrategy = DuplicatesStrategy.WARN
+        isPreserveFileTimestamps = false
+        isReproducibleFileOrder = true
     }
 }


### PR DESCRIPTION
## Summary

- Add `@CacheableTask` to `HivemqExtensionZip` so it can hit the Gradle build cache.
- Set `isPreserveFileTimestamps = false` and `isReproducibleFileOrder = true` in the `init {}` block so cached archive bytes are deterministic across machines.

## Why

`HivemqExtensionZip` extends `org.gradle.api.tasks.bundling.Zip`, which inherits `@DisableCachingByDefault` from `AbstractArchiveTask`. Every `hivemqExtensionProguardedZip` / `hivemqExtensionZip` task instance across the HiveMQ extension ecosystem therefore re-executes on every build with zero cache hits. The sibling task type `HivemqEnterpriseExtensionSignature` is already `@CacheableTask`, so this brings the rest of the family into line.

## Scope

Develocity Reporting Kit data (last 30 days of CI in the `hivemq` composite project), aggregated across the 13 enterprise extensions:

| Task family | Avg / build (s) | Runs / 30 days | Cache hits |
| ----------- | --: | --: | --: |
| `:*:hivemqExtensionProguardedZip` (13 extensions) | ~21 s combined | ~10 700 | 0 |

Net wasted CI compute on this task family alone: roughly **14 h / month**. The companion change in [hivemq/hivemq-enterprise-extension-gradle-plugin#fix-proguarded-jar-cacheable](https://github.com/hivemq/hivemq-enterprise-extension-gradle-plugin/pulls) covers the wrapping `Jar` task in the same chain (`hivemqExtensionProguardedJar`, ~63 s / build) and depends on this change.

## Validation

End-to-end validation against `hivemq-kafka-extension`, building `hivemqExtensionProguardedZip` twice from the same commit with both patches applied via composite-build substitution:

| Build | Build Scan | Outcome for `:hivemqExtensionProguardedZip` |
| ----- | ---------- | ------- |
| Populate (cold cache) | https://gradle.cicd.pd.hmq.dev/s/6ewshhyykhzrw | executed |
| Validate (after wipe) | https://gradle.cicd.pd.hmq.dev/s/kdozarcrwofb2 | executed — `nonCacheabilityReason: \"'Has custom actions' satisfied\"` |

The shift in `nonCacheabilityReason` from \"Caching has not been enabled for the task\" (pre-patch baseline DRV) to \"'Has custom actions' satisfied\" (post-patch) is the proof that `@CacheableTask` is now in effect — Gradle is willing to cache; a separate `outputs.doNotCacheIf(\"Has custom actions\")` from some plugin in the kafka extension's classpath is the remaining blocker.

Overall build cache avoidance ratio on the validation build jumped from the pre-patch baseline to **91.2 %** thanks to the upstream chain (`UnsignedJar`, `UnsignedProguardedJar`, `ProguardedSignature`) all hitting cache cleanly.

## Test plan

- [ ] CI green
- [ ] In a downstream consumer build (any HiveMQ enterprise extension), confirm via Build Scan that `hivemqExtensionProguardedZip` now reports `nonCacheabilityCategory` other than `task_output_caching_not_enabled`
- [ ] Spot-check: build the same extension twice from a clean checkout with `--build-cache` and verify the archive bytes are byte-identical (`shasum` on the output zip)

## Follow-up

A separate follow-up issue is needed to track down the source of the \"Has custom actions\" predicate that is currently blocking the actual cache hit on the downstream consumer side. This PR is a strict prerequisite for that follow-up — without `@CacheableTask` on the class, no downstream fix to the custom-actions issue could take effect.