### PR TITLE
fix: resolve hivemqProvided lazily to avoid configuration-time resolution

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 # Gradle
 .gradle
 build/
+kotlin-compiler-*
 
 # IntelliJ
 out/

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ This Gradle plugin eases the development of HiveMQ extensions.
 Contents of the `build.gradle(.kts)` file:
 ```kotlin
 plugins {
-    id("com.hivemq.extension") version "5.0.0"
+    id("com.hivemq.extension") version "5.0.1"
 }
 
 group = "org.example"
@@ -22,7 +22,7 @@ hivemqExtension {
     priority = 0
     startPriority = 1000
     mainClass = "org.example.ExtensionMain"
-    sdkVersion = "4.49.0"
+    sdkVersion = "4.50.0"
 }
 ```
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-version=5.0.0
+version=5.0.1
 #
 # options
 #

--- a/src/main/kotlin/com/hivemq/extension/gradle/HivemqExtensionPlugin.kt
+++ b/src/main/kotlin/com/hivemq/extension/gradle/HivemqExtensionPlugin.kt
@@ -145,11 +145,17 @@ class HivemqExtensionPlugin : Plugin<Project> {
             from(project.extensions.getByType<SourceSetContainer>()[SourceSet.MAIN_SOURCE_SET_NAME].output)
             configurations = listOf(project.configurations[JavaPlugin.RUNTIME_CLASSPATH_CONFIGURATION_NAME])
             val providedConfiguration = project.configurations[PROVIDED_CONFIGURATION_NAME]
-            for (component in providedConfiguration.incoming.resolutionResult.allComponents) {
-                val id = component.moduleVersion
-                if (id != null) {
-                    dependencyFilter.exclude(dependencyFilter.dependency("${id.group}:${id.name}"))
-                }
+            // Resolve the provided configuration lazily, at execution time. Resolving it during task configuration
+            // fails under Gradle 9+ when a project is configured without holding its exclusive lock (e.g. in a
+            // composite build): "Resolution of the configuration ':...:hivemqProvided' was attempted without an
+            // exclusive lock. This is unsafe and not allowed."
+            val providedModuleIds by lazy {
+                providedConfiguration.incoming.resolutionResult.allComponents
+                    .mapNotNull { it.moduleVersion }
+                    .mapTo(HashSet()) { "${it.group}:${it.name}" }
+            }
+            dependencyFilter.exclude { resolvedDependency ->
+                "${resolvedDependency.moduleGroup}:${resolvedDependency.moduleName}" in providedModuleIds
             }
             exclude("META-INF/INDEX.LIST", "META-INF/*.SF", "META-INF/*.DSA", "META-INF/*.RSA", "module-info.class")
             mergeServiceFiles()

--- a/src/test/kotlin/com/hivemq/extension/gradle/ProvidedConfigurationResolutionTest.kt
+++ b/src/test/kotlin/com/hivemq/extension/gradle/ProvidedConfigurationResolutionTest.kt
@@ -1,0 +1,110 @@
+/*
+ * Copyright 2020-present HiveMQ and the HiveMQ Community
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.hivemq.extension.gradle
+
+import org.assertj.core.api.Assertions.assertThat
+import org.gradle.testkit.runner.GradleRunner
+import org.gradle.testkit.runner.TaskOutcome
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.io.TempDir
+import java.io.File
+
+/**
+ * The shadow jar task must not resolve the `hivemqProvided` configuration at configuration time.
+ *
+ * Gradle 9+ forbids resolving a configuration while the owning project's exclusive lock is not held.
+ * A composite build that consumes the extension as an included (composite) build configures the
+ * extension without holding its state lock, so resolving `hivemqProvided` eagerly inside the jar
+ * task's configuration action fails the whole build with:
+ *
+ *   Resolution of the configuration ':...:hivemqProvided' was attempted without an exclusive lock.
+ *   This is unsafe and not allowed.
+ *
+ * This is reproduced here by driving the extension's jar task from an outer build via `includeBuild`.
+ */
+internal class ProvidedConfigurationResolutionTest {
+
+    @Test
+    fun jarTaskConfiguration_doesNotResolveProvidedConfiguration(@TempDir projectDir: File) {
+        // The plugin classpath that TestKit would normally inject into the build under test. We inject
+        // it into the included build's buildscript so the plugin can be applied there.
+        val pluginClasspath = GradleRunner.create().withPluginClasspath().pluginClasspath
+            .joinToString(", ") { "\"${it.invariantSeparatorsPath}\"" }
+
+        // ---- included build: a normal HiveMQ extension ----
+        val extensionDir = projectDir.resolve("extension").apply { mkdirs() }
+        extensionDir.resolve("settings.gradle.kts").writeText(
+            """
+            rootProject.name = "extension"
+            """.trimIndent()
+        )
+        extensionDir.resolve("build.gradle.kts").writeText(
+            """
+            buildscript {
+                dependencies {
+                    classpath(files($pluginClasspath))
+                }
+            }
+            apply(plugin = "com.hivemq.extension")
+            version = "1.0.0"
+            the<com.hivemq.extension.gradle.HivemqExtensionExtension>().apply {
+                name.set("Test Extension")
+                author.set("HiveMQ")
+                sdkVersion.set("4.17.0")
+            }
+            """.trimIndent()
+        )
+        extensionDir.resolve("src/main/java/test/TestExtensionMain.java").apply { parentFile.mkdirs() }.writeText(
+            """
+            package test;
+            import com.hivemq.extension.sdk.api.ExtensionMain;
+            import com.hivemq.extension.sdk.api.parameter.ExtensionStartInput;
+            import com.hivemq.extension.sdk.api.parameter.ExtensionStartOutput;
+            import com.hivemq.extension.sdk.api.parameter.ExtensionStopInput;
+            import com.hivemq.extension.sdk.api.parameter.ExtensionStopOutput;
+            public class TestExtensionMain implements ExtensionMain {
+                @Override
+                public void extensionStart(final ExtensionStartInput input, final ExtensionStartOutput output) {}
+                @Override
+                public void extensionStop(final ExtensionStopInput input, final ExtensionStopOutput output) {}
+            }
+            """.trimIndent()
+        )
+
+        // ---- outer build: consumes the extension as an included build (like the composite) ----
+        projectDir.resolve("settings.gradle.kts").writeText(
+            """
+            rootProject.name = "composite"
+            includeBuild("extension")
+            """.trimIndent()
+        )
+        projectDir.resolve("build.gradle.kts").writeText(
+            """
+            tasks.register("buildExtension") {
+                dependsOn(gradle.includedBuild("extension").task(":hivemqExtensionJar"))
+            }
+            """.trimIndent()
+        )
+
+        val result = GradleRunner.create()
+            .withProjectDir(projectDir)
+            .withArguments("buildExtension")
+            .build()
+
+        assertThat(result.output).doesNotContain("without an exclusive lock")
+        assertThat(result.task(":extension:hivemqExtensionJar")?.outcome).isEqualTo(TaskOutcome.SUCCESS)
+    }
+}


### PR DESCRIPTION
## Problem

The shadow jar task (`hivemqExtension[Classifier]Jar`) resolved the `hivemqProvided` configuration inside its **configuration action**. Gradle 9+ forbids resolving a configuration while the owning project's exclusive lock is not held, which is the case when the extension is consumed as an **included build of a composite build**. The build then fails with:

```
Could not create task ':...:hivemqExtensionUnsignedJar'.
> Resolution of the configuration ':...:hivemqProvided' was attempted without an exclusive lock. This is unsafe and not allowed.
```

A standalone build of the extension worked because single-project configuration holds the lock; the failure only surfaced in composite builds.

## Fix

Defer the resolution to **execution time** via a lazy provider inside the dependency-filter spec, keeping the same exclude semantics (a provided dependency is excluded from the shadow jar). The set is memoized so resolution happens once.

## Test

Adds a TestKit test that drives the extension's jar task from an outer build via `includeBuild`, reproducing the exact failure. It fails on the old eager code and passes with the fix.